### PR TITLE
chore: referencing workspace packages through aliases

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -14,7 +14,7 @@
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.18.9",
-		"@boilertowns-example/ui": "*",
+		"@boilertowns-example/ui": "workspace:*",
 		"@emotion/react": "^11.10.0",
 		"@emotion/styled": "^11.10.0",
 		"core-js": "^3.24.1",
@@ -31,7 +31,7 @@
 		"@babel/preset-env": "^7.18.10",
 		"@babel/preset-react": "^7.18.6",
 		"@babel/preset-typescript": "^7.18.6",
-		"@boilertowns-example/tsconfig": "*",
+		"@boilertowns-example/tsconfig": "workspace:*",
 		"babel-loader": "^8.2.5",
 		"copy-webpack-plugin": "^11.0.0",
 		"css-minimizer-webpack-plugin": "^4.0.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,7 @@
 		"not op_mini all"
 	],
 	"dependencies": {
-		"@boilertowns-example/ui": "*",
+		"@boilertowns-example/ui": "workspace:*",
 		"@emotion/react": "^11.10.0",
 		"@emotion/styled": "^11.10.0",
 		"next": "^12.2.4",
@@ -23,7 +23,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.18.10",
-		"@boilertowns-example/tsconfig": "*",
+		"@boilertowns-example/tsconfig": "workspace:*",
 		"next-transpile-modules": "^9.0.0"
 	},
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	],
 	"scripts": {
 		"bootstrap": "turbo run build",
+		"bootstrap:packages": "turbo run build --filter=./packages/*",
 		"changeset": "changeset",
 		"dev": "turbo run dev",
 		"lint": "eslint . --ext .ts,.tsx,.js,.jsx",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,7 +24,7 @@
 		"@babel/plugin-transform-runtime": "^7.18.10",
 		"@babel/preset-env": "^7.18.10",
 		"@babel/preset-react": "^7.18.6",
-		"@boilertowns-example/tsconfig": "*",
+		"@boilertowns-example/tsconfig": "workspace:*",
 		"@emotion/babel-plugin": "^11.10.0",
 		"@emotion/react": "^11.10.0",
 		"@emotion/styled": "^11.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
       '@babel/preset-react': ^7.18.6
       '@babel/preset-typescript': ^7.18.6
       '@babel/runtime': ^7.18.9
-      '@boilertowns-example/tsconfig': '*'
-      '@boilertowns-example/ui': '*'
+      '@boilertowns-example/tsconfig': workspace:*
+      '@boilertowns-example/ui': workspace:*
       '@emotion/react': ^11.10.0
       '@emotion/styled': ^11.10.0
       babel-loader: ^8.2.5
@@ -118,8 +118,8 @@ importers:
   apps/web:
     specifiers:
       '@babel/core': ^7.18.10
-      '@boilertowns-example/tsconfig': '*'
-      '@boilertowns-example/ui': '*'
+      '@boilertowns-example/tsconfig': workspace:*
+      '@boilertowns-example/ui': workspace:*
       '@emotion/react': ^11.10.0
       '@emotion/styled': ^11.10.0
       next: ^12.2.4
@@ -148,7 +148,7 @@ importers:
       '@babel/preset-env': ^7.18.10
       '@babel/preset-react': ^7.18.6
       '@babel/runtime': ^7.18.9
-      '@boilertowns-example/tsconfig': '*'
+      '@boilertowns-example/tsconfig': workspace:*
       '@emotion/babel-plugin': ^11.10.0
       '@emotion/react': ^11.10.0
       '@emotion/styled': ^11.10.0
@@ -5387,7 +5387,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       webpack: 5.74.0_webpack-cli@4.10.0
-      webpack-cli: 4.10.0_3lewgxathpayo2pqi2m465vtiu
+      webpack-cli: 4.10.0_webpack@5.74.0
     dev: true
 
   /@webpack-cli/info/1.5.0_webpack-cli@4.10.0:
@@ -5396,7 +5396,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.10.0_3lewgxathpayo2pqi2m465vtiu
+      webpack-cli: 4.10.0_webpack@5.74.0
     dev: true
 
   /@webpack-cli/serve/1.7.0_jrmoy2z4ppm6sherzyq2k2csya:
@@ -16172,7 +16172,7 @@ packages:
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.3_webpack@5.74.0
       watchpack: 2.4.0
-      webpack-cli: 4.10.0_3lewgxathpayo2pqi2m465vtiu
+      webpack-cli: 4.10.0_webpack@5.74.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'


### PR DESCRIPTION
## Summary

Use aliases to referencing workspace packages and edit this alias later when using `create-boilertowns`.

## References

https://pnpm.io/workspaces#referencing-workspace-packages-through-aliases